### PR TITLE
TLF-305: base64 encode URL parameters;

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ Acquire the secret key (`QUERY_KEY`) for your selected environment from Kubernet
 To generate the link with HMAC using Node.js, you can use the following command. Make sure to replace the placeholders `<SECRET KEY>`, `<FORM>` and `<RETURN URL>` with your actual secret key, form and returnUrl you want to hash, respectively:
 
 ```javascript
-node -e "const { createHmac } = require('node:crypto'); const algorithm = 'sha256'; const key = '<SECRET KEY>'; const refObject = {form: btoa('<FORM>'), returnUrl: btoa('<RETURN URL>')}; const message = JSON.stringify(refObject); const encoding = 'hex'; const hmac = createHmac(algorithm, key).update(message).digest(encoding); console.log('https://hof-feedback.homeoffice.gov.uk?form=' + refObject.form + '&returnUrl=' + refObject.returnUrl + '&mac=' + hmac);"
+node -e "const { createHmac } = require('node:crypto'); const { Buffer } = require('node:buffer'); const algorithm = 'sha256'; const key = '<SECRET KEY>'; const refObject = {form: Buffer.from('<FORM>', 'utf8').toString('base64'), returnUrl: Buffer.from('<RETURN URL>', 'utf8').toString('base64')}; const message = JSON.stringify(refObject); const encoding = 'hex'; const hmac = createHmac(algorithm, key).update(message).digest(encoding); console.log('https://hof-feedback.homeoffice.gov.uk?form=' + refObject.form + '&returnUrl=' + refObject.returnUrl + '&mac=' + hmac);"
 ```
 
 _Please ensure that the object keys/params are in the order as given in the example above._
@@ -172,7 +172,7 @@ This will output a ready-to-use link with the HMAC for the given message, which 
 Example:
 
 ```bash
-node -e "const { createHmac } = require('node:crypto'); const algorithm = 'sha256'; const key = 'skeletonKey'; const refObject = {form: btoa('ASC'), returnUrl: btoa('https://www.asc.homeoffice.gov.uk')}; const message = JSON.stringify(refObject); const encoding = 'hex'; const hmac = createHmac(algorithm, key).update(message).digest(encoding); console.log('https://hof-feedback.homeoffice.gov.uk?form=' + refObject.form + '&returnUrl=' + refObject.returnUrl + '&mac=' + hmac);"
+node -e "const { createHmac } = require('node:crypto'); const { Buffer } = require('node:buffer'); const algorithm = 'sha256'; const key = 'skeletonKey'; const refObject = {form: Buffer.from('ASC', 'utf8').toString('base64'), returnUrl: Buffer.from('https://www.asc.homeoffice.gov.uk', 'utf8').toString('base64')}; const message = JSON.stringify(refObject); const encoding = 'hex'; const hmac = createHmac(algorithm, key).update(message).digest(encoding); console.log('https://hof-feedback.homeoffice.gov.uk?form=' + refObject.form + '&returnUrl=' + refObject.returnUrl + '&mac=' + hmac);"
 ```
 Expected output:
 

--- a/README.md
+++ b/README.md
@@ -172,10 +172,11 @@ This will output a ready-to-use link with the HMAC for the given message, which 
 Example:
 
 ```bash
-node -e "const { createHmac } = require('node:crypto'); const { Buffer } = require('node:buffer'); const algorithm = 'sha256'; const key = 'skeletonKey'; const refObject = {form: Buffer.from('ASC', 'utf8').toString('base64'), returnUrl: Buffer.from('https://www.asc.homeoffice.gov.uk', 'utf8').toString('base64')}; const message = JSON.stringify(refObject); const encoding = 'hex'; const hmac = createHmac(algorithm, key).update(message).digest(encoding); console.log('https://hof-feedback.homeoffice.gov.uk?form=' + refObject.form + '&returnUrl=' + refObject.returnUrl + '&mac=' + hmac);"
+node -e "const { createHmac } = require('node:crypto'); const { Buffer } = require('node:buffer'); const algorithm = 'sha256'; const key = 'skeletonKey'; const refObject = {form: Buffer.from('Fake Form', 'utf8').toString('base64'), returnUrl: Buffer.from('https://www.fake-service.homeoffice.gov.uk', 'utf8').toString('base64')}; const message = JSON.stringify(refObject); const encoding = 'hex'; const hmac = createHmac(algorithm, key).update(message).digest(encoding); console.log('https://hof-feedback.homeoffice.gov.uk?form=' + refObject.form + '&returnUrl=' + refObject.returnUrl + '&mac=' + hmac);"
 ```
 Expected output:
 
 ```bash
-https://hof-feedback.homeoffice.gov.uk?form=TXkgSE8gRm9ybQ==&returnUrl=aHR0cHM6Ly93d3cubXktaG8tZm9ybS5ob21lb2ZmaWNlLmdvdi51aw==&mac=1a43ba473a484513462fc892223b4bdf280d0ee3050c8dc088d57fcbcef1bf95
+https://hof-feedback.homeoffice.gov.uk?form=RmFrZSBGb3Jt&returnUrl=aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr&mac=32a913dc951a771f7b8b8ac4e12db6cb615850fb23ac7cfc65d8ae06e62b5577
+
 ```

--- a/apps/hff/behaviours/get-service-query.js
+++ b/apps/hff/behaviours/get-service-query.js
@@ -1,7 +1,8 @@
 const config = require('../../../config');
 const serviceReferrerNameRegex = config.regex.serviceReferrerName;
+const macPatternRegex = config.regex.macPattern;
+const base64PatternRegex = config.regex.base64Pattern;
 const { queryKey, algorithm, encoding } = config.hmac;
-const logger = require('hof/lib/logger')({ env: config.env });
 const { createHmacDigest } = require('../../../utils');
 module.exports = superclass => class extends superclass {
   configure(req, res, next) {
@@ -9,32 +10,41 @@ module.exports = superclass => class extends superclass {
       return super.configure(req, res, next);
     }
 
-    const { form, returnUrl, mac } = req.query;
+    const { form: formBase64, returnUrl: returnUrlBase64, mac } = req.query;
+
+    if (!macPatternRegex.test(mac)) {
+      req.log('warn', 'MAC query parameter is not valid');
+      return super.configure(req, res, next);
+    }
+
+    if (!base64PatternRegex.test(formBase64) || !base64PatternRegex.test(returnUrlBase64)) {
+      req.log('warn', 'Either form or returnURL query parameter is invalid');
+      return super.configure(req, res, next);
+    }
 
     try {
       const comparisonObject = {};
 
-      if (form) {
-        comparisonObject.form = decodeURIComponent(form);
+      if (formBase64) {
+        comparisonObject.form = formBase64;
       }
 
-      if (returnUrl) {
-        comparisonObject.returnUrl = decodeURIComponent(returnUrl);
+      if (returnUrlBase64) {
+        comparisonObject.returnUrl = returnUrlBase64;
       }
 
       const comparisonString = JSON.stringify(comparisonObject);
-
       const hashedAndHexed = createHmacDigest(algorithm, queryKey, comparisonString, encoding);
 
       if (mac === hashedAndHexed) {
-        logger.info('HMAC matched OK');
-        const decodedForm = comparisonObject.form;
-        const decodedReturnUrl = comparisonObject.returnUrl;
+        req.log('info', 'HMAC matched OK');
+        const decodedForm = atob(formBase64);
+        const decodedReturnUrl = atob(returnUrlBase64);
 
         if (decodedForm && serviceReferrerNameRegex.test(decodedForm)) {
           req.sessionModel.set('service-referrer-name', decodedForm);
         } else {
-          logger.info(`Service name is undefined or formatting of ${decodedForm} is not valid`);
+          req.log('warn', `Service name is undefined or formatting of [${decodedForm}] is not valid`);
         }
 
         if (decodedReturnUrl && URL.canParse(decodedReturnUrl)) {
@@ -42,13 +52,13 @@ module.exports = superclass => class extends superclass {
           const { origin } = serviceUrl;
           req.sessionModel.set('service-referrer-url', origin);
         } else {
-          logger.info(`Service URL is undefined or formatting of ${decodedReturnUrl} is not valid`);
+          req.log('warn', `Service URL is undefined or formatting of [${decodedReturnUrl}] is not valid`);
         }
       } else {
-        logger.error('given mac query parameter does not match new HMAC');
+        req.log('warn', 'Given mac query parameter does not match new HMAC');
       }
     } catch (error) {
-      logger.error('There was a problem matching query to validation requirements', error);
+      req.log('error', 'There was a problem matching query to validation requirements', error);
     }
     return super.configure(req, res, next);
   }

--- a/apps/hff/behaviours/get-service-query.js
+++ b/apps/hff/behaviours/get-service-query.js
@@ -3,7 +3,7 @@ const serviceReferrerNameRegex = config.regex.serviceReferrerName;
 const macPatternRegex = config.regex.macPattern;
 const base64PatternRegex = config.regex.base64Pattern;
 const { queryKey, algorithm, encoding } = config.hmac;
-const { createHmacDigest } = require('../../../utils');
+const { createHmacDigest, base64Decode} = require('../../../utils');
 module.exports = superclass => class extends superclass {
   configure(req, res, next) {
     if (!req.query || !req.query.mac || !queryKey) {
@@ -38,8 +38,8 @@ module.exports = superclass => class extends superclass {
 
       if (mac === hashedAndHexed) {
         req.log('info', 'HMAC matched OK');
-        const decodedForm = atob(formBase64);
-        const decodedReturnUrl = atob(returnUrlBase64);
+        const decodedForm = base64Decode(formBase64);
+        const decodedReturnUrl = base64Decode(returnUrlBase64);
 
         if (decodedForm && serviceReferrerNameRegex.test(decodedForm)) {
           req.sessionModel.set('service-referrer-name', decodedForm);

--- a/config.js
+++ b/config.js
@@ -20,6 +20,8 @@ module.exports = {
     encoding: 'hex'
   },
   regex: {
-    serviceReferrerName: /^[\w\s\-]*$/
+    serviceReferrerName: /^[\w\s\-]*$/,
+    base64Pattern: /^[A-Za-z0-9+/=]+$/,
+    macPattern: /^[a-fA-F0-9]{64}$/
   }
 };

--- a/test/unit/behaviours/get-service-query.test.js
+++ b/test/unit/behaviours/get-service-query.test.js
@@ -32,12 +32,12 @@ describe('get-service-query behaviour', () => {
   describe('The \'configure\' method', () => {
     beforeEach(() => {
       req.query = {
-        form: 'ASC',
-        returnUrl: 'https://www.fake-service.homeoffice.gov.uk',
-        mac: '686173686564616e6468657865640a'
+        form: 'QVND', // 'ASC' in base64
+        returnUrl: 'aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr', // 'https://www.fake-service.homeoffice.gov.uk' in base64
+        mac: '5045060455395a109a61689ee2f5d989e3df3dc24e1768e00853b34b800df148'
       };
 
-      utils.createHmacDigest.mockReturnValue('686173686564616e6468657865640a');
+      utils.createHmacDigest.mockReturnValue('5045060455395a109a61689ee2f5d989e3df3dc24e1768e00853b34b800df148');
     });
 
 
@@ -63,27 +63,27 @@ describe('get-service-query behaviour', () => {
     });
 
     test('form value will be URI decoded before comparison and storage', () => {
-      req.query.form = 'new%20form';
+      req.query.form = 'bmV3IGZvcm0='; // 'new form' in base64
       instance.configure(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe('new form');
     });
 
     test('does not add a service name query value to session if it does not match the proper format', () => {
-      req.query.form = 'ASC!';
+      req.query.form = 'QVNDIQ=='; // 'ASC!' in base64
       instance.configure(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe(undefined);
     });
 
     test('does not add a returnUrl query value to session if it does not match the proper format', () => {
-      req.query.returnUrl = 'fake-service.homeoffice.gov.uk';
+      req.query.returnUrl = 'ZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr'; // 'fake-service.homeoffice.gov.uk' in base64
       instance.configure(req, res, next);
       expect(req.sessionModel.get('service-referrer-url')).toBe(undefined);
     });
 
     test('does not set service-referrer-name and -url if no mac is added to query', () => {
       req.query = {
-        form: 'ASC',
-        returnUrl: 'https://www.fake-service.homeoffice.gov.uk'
+        form: 'QVNDIQ==', // 'ASC!' in base64
+        returnUrl: 'aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr' // 'https://www.fake-service.homeoffice.gov.uk' in base64
       };
       instance.configure(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe(undefined);
@@ -92,8 +92,8 @@ describe('get-service-query behaviour', () => {
 
     test('does not set service-referrer-name and -url if the query mac does not match a new hash', () => {
       req.query = {
-        form: 'ASC',
-        returnUrl: 'https://www.fake-service.homeoffice.gov.uk',
+        form: 'QVNDIQ==', // 'ASC!' in base64
+        returnUrl: 'aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr', // 'https://www.fake-service.homeoffice.gov.uk' in base64
         mac: '786173686564616e6468657865640b'
       };
       instance.configure(req, res, next);
@@ -114,8 +114,8 @@ describe('get-service-query behaviour', () => {
 
     test('does not assign a form value if it is not URI decodable', () => {
       req.query = {
-        form: 'ASC%2!',
-        returnUrl: 'https://www.fake-service.homeoffice.gov.uk'
+        form: 'QVNDJSE=', // 'ASC%!' in base64
+        returnUrl: 'aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr' // 'https://www.fake-service.homeoffice.gov.uk' in base64
       };
       instance.configure(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe(undefined);

--- a/test/unit/behaviours/get-service-query.test.js
+++ b/test/unit/behaviours/get-service-query.test.js
@@ -1,7 +1,14 @@
 const Behaviour = require('../../../apps/hff/behaviours/get-service-query');
 const reqres = require('hof').utils.reqres;
+
 const utils = require('../../../utils');
-jest.mock('../../../utils');
+jest.mock('../../../utils', () => {
+  const originalModule = jest.requireActual('../../../utils');
+  return {
+    ...originalModule,
+    createHmacDigest: jest.fn().mockReturnValue('5045060455395a109a61689ee2f5d989e3df3dc24e1768e00853b34b800df148')
+  };
+});
 
 describe('get-service-query behaviour', () => {
   test('Behaviour exports a function', () => {
@@ -38,8 +45,6 @@ describe('get-service-query behaviour', () => {
         returnUrl: 'aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr',
         mac: '5045060455395a109a61689ee2f5d989e3df3dc24e1768e00853b34b800df148'
       };
-
-      utils.createHmacDigest.mockReturnValue('5045060455395a109a61689ee2f5d989e3df3dc24e1768e00853b34b800df148');
     });
 
 

--- a/test/unit/behaviours/get-service-query.test.js
+++ b/test/unit/behaviours/get-service-query.test.js
@@ -32,8 +32,10 @@ describe('get-service-query behaviour', () => {
   describe('The \'configure\' method', () => {
     beforeEach(() => {
       req.query = {
-        form: 'QVND', // 'ASC' in base64
-        returnUrl: 'aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr', // 'https://www.fake-service.homeoffice.gov.uk' in base64
+        // 'ASC' in base64
+        form: 'QVND',
+        // 'https://www.fake-service.homeoffice.gov.uk' in base64
+        returnUrl: 'aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr',
         mac: '5045060455395a109a61689ee2f5d989e3df3dc24e1768e00853b34b800df148'
       };
 
@@ -63,27 +65,32 @@ describe('get-service-query behaviour', () => {
     });
 
     test('form value will be URI decoded before comparison and storage', () => {
-      req.query.form = 'bmV3IGZvcm0='; // 'new form' in base64
+      // 'new form' in base64
+      req.query.form = 'bmV3IGZvcm0=';
       instance.configure(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe('new form');
     });
 
     test('does not add a service name query value to session if it does not match the proper format', () => {
-      req.query.form = 'QVNDIQ=='; // 'ASC!' in base64
+      // 'ASC!' in base64
+      req.query.form = 'QVNDIQ==';
       instance.configure(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe(undefined);
     });
 
     test('does not add a returnUrl query value to session if it does not match the proper format', () => {
-      req.query.returnUrl = 'ZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr'; // 'fake-service.homeoffice.gov.uk' in base64
+      // 'fake-service.homeoffice.gov.uk' in base64
+      req.query.returnUrl = 'ZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr';
       instance.configure(req, res, next);
       expect(req.sessionModel.get('service-referrer-url')).toBe(undefined);
     });
 
     test('does not set service-referrer-name and -url if no mac is added to query', () => {
       req.query = {
-        form: 'QVNDIQ==', // 'ASC!' in base64
-        returnUrl: 'aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr' // 'https://www.fake-service.homeoffice.gov.uk' in base64
+        // 'ASC!' in base64
+        form: 'QVNDIQ==',
+        // 'https://www.fake-service.homeoffice.gov.uk' in base64
+        returnUrl: 'aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr'
       };
       instance.configure(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe(undefined);
@@ -92,8 +99,10 @@ describe('get-service-query behaviour', () => {
 
     test('does not set service-referrer-name and -url if the query mac does not match a new hash', () => {
       req.query = {
-        form: 'QVNDIQ==', // 'ASC!' in base64
-        returnUrl: 'aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr', // 'https://www.fake-service.homeoffice.gov.uk' in base64
+        // 'ASC!' in base64
+        form: 'QVNDIQ==',
+        // 'https://www.fake-service.homeoffice.gov.uk' in base64
+        returnUrl: 'aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr',
         mac: '786173686564616e6468657865640b'
       };
       instance.configure(req, res, next);
@@ -114,8 +123,10 @@ describe('get-service-query behaviour', () => {
 
     test('does not assign a form value if it is not URI decodable', () => {
       req.query = {
-        form: 'QVNDJSE=', // 'ASC%!' in base64
-        returnUrl: 'aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr' // 'https://www.fake-service.homeoffice.gov.uk' in base64
+        // 'ASC%!' in base64
+        form: 'QVNDJSE=',
+        // 'https://www.fake-service.homeoffice.gov.uk' in base64
+        returnUrl: 'aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr'
       };
       instance.configure(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe(undefined);

--- a/utils/index.js
+++ b/utils/index.js
@@ -1,4 +1,5 @@
 const { createHmac } = require('node:crypto');
+const { Buffer } = require('node:buffer');
 const translations = require('../apps/hff/translations/src/en/fields.json');
 
 const getLabel = (fieldKey, fieldValue) => {
@@ -26,4 +27,6 @@ const createHmacDigest = (algorithm, key, message, encoding) => {
   return createHmac(algorithm, key).update(message).digest(encoding);
 };
 
-module.exports = { getLabel, createHmacDigest };
+const base64Decode = data => Buffer.from(data, 'base64').toString('utf-8');
+
+module.exports = { getLabel, createHmacDigest, base64Decode};


### PR DESCRIPTION
## What?
[TLF-305](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-305) HFF: Encode URL parameters to bypass NAXSI filtering on nginx proxy
## Why?
Requests are rejected by NAXSI filtering on the NGINX proxy due to the context of the parameters in the URL. 
To bypass this filtering, the implementation of the request parser should be modified to accept encoded parameters.

## How?
query parameters are Base64 encoded

## Testing?

## Screenshots (optional)

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
