### PR TITLE
Tlf 305 hex version

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Add some `feedback` values to your `config.js`:
 {
   feedback: {
     url: 'https://hof-feedback.homeoffice.gov.uk', // required if you want a feedback banner and link to feedback form
-    form: '46616b6520466f726d', // optional hex encoded form name if you want to include this context in the feedback notification email
-    returnUrl: '68747470733a2f2f7777772e66616b652d736572766963652e686f6d656f66666963652e676f762e756b', // optional hex encoded URL if you want a link back to your form in the feedback email
+    form: Buffer.from('<FORM>', 'utf-8').toString('hex'), // hex encode your form name if you want to include this context in the feedback notification email
+    returnUrl: Buffer.from('<RETURN URL>', 'utf-8').toString('hex'), // hex encode a URL if you want a link back to your form included in the feedback email
     mac: 'pre-hashed mac of the above two params in a JSON object string' // required if you add one or both of form and returnUrl
   }
 }

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Add some `feedback` values to your `config.js`:
 {
   feedback: {
     url: 'https://hof-feedback.homeoffice.gov.uk', // required if you want a feedback banner and link to feedback form
-    form: encodeURIComponent('your form name or alias'), // optional if you want to include this context
-    returnUrl: 'https://www.your-form-url.homeoffice.gov.uk', // optional if you want a return URL to your form in the feedback email
+    form: '46616b6520466f726d', // optional hex encoded form name if you want to include this context in the feedback notification email
+    returnUrl: '68747470733a2f2f7777772e66616b652d736572766963652e686f6d656f66666963652e676f762e756b', // optional hex encoded URL if you want a link back to your form in the feedback email
     mac: 'pre-hashed mac of the above two params in a JSON object string' // required if you add one or both of form and returnUrl
   }
 }
@@ -105,7 +105,10 @@ Add some `feedback` values to your `config.js`:
 Assign the following to `res.locals.feedbackUrl`. See [below](#query-parameters) for information about use of query parameter context.
 
 ```javascript
+// import values set in config
 const { url, form, returnUrl, mac } = require('config.js').feedback;
+
+// add the following template literal using above config values or a complete URL string to an app.use function
 res.locals.feedbackUrl = `${url}?form=${form}&returnUrl=${returnUrl}&mac=${mac}`
 ```
 
@@ -135,7 +138,7 @@ Including these parameters in links to this form is optional, but may improve th
 
 ### Creating a MAC for your URL query
 
-To have your query parameters trusted by this application, the `form` and `returnUrl` parameters need to be Base64 encoded. Additionally, the query parameters must be signed by an HMAC that is then appended to the query string as 'mac'. e.g.
+To have your query parameters trusted by this application, the `form` and `returnUrl` parameters need to be hex encoded. Additionally, the query parameters must be signed by an HMAC that is then appended to the query string as 'mac'. e.g.
 
 ```bash
 https://hof-feedback.homeoffice.gov.uk?form=ASC&returnUrl=https://www.asc.homeoffice.gov.uk
@@ -152,7 +155,7 @@ The 'mac' parameter is generated as below from a hash of a JSON object string, a
 #### HMAC generation Prerequisites
 
 - The secret key to sign the MAC with.
-- A JavaScript object structure containing the Base64 encoded `form` and `returnUrl` values you want to include as context in the link
+- A JavaScript object structure containing the hex encoded `form` and `returnUrl` values you want to include as context in the link
 - Node.js - ideally use the same version running in this app.
 
 #### Generating HMAC and Constructing URL
@@ -162,7 +165,7 @@ Acquire the secret key (`QUERY_KEY`) for your selected environment from Kubernet
 To generate the link with HMAC using Node.js, you can use the following command. Make sure to replace the placeholders `<SECRET KEY>`, `<FORM>` and `<RETURN URL>` with your actual secret key, form and returnUrl you want to hash, respectively:
 
 ```javascript
-node -e "const { createHmac } = require('node:crypto'); const { Buffer } = require('node:buffer'); const algorithm = 'sha256'; const key = '<SECRET KEY>'; const refObject = {form: Buffer.from('<FORM>', 'utf8').toString('base64'), returnUrl: Buffer.from('<RETURN URL>', 'utf8').toString('base64')}; const message = JSON.stringify(refObject); const encoding = 'hex'; const hmac = createHmac(algorithm, key).update(message).digest(encoding); console.log('https://hof-feedback.homeoffice.gov.uk?form=' + refObject.form + '&returnUrl=' + refObject.returnUrl + '&mac=' + hmac);"
+node -e "const { createHmac } = require('node:crypto'); const { Buffer } = require('node:buffer'); const algorithm = 'sha256'; const key = '<SECRET KEY>'; const refObject = {form: Buffer.from('<FORM>', 'utf8').toString('hex'), returnUrl: Buffer.from('<RETURN URL>', 'utf8').toString('hex')}; const message = JSON.stringify(refObject); const encoding = 'hex'; const hmac = createHmac(algorithm, key).update(message).digest(encoding); console.log('https://hof-feedback.homeoffice.gov.uk?form=' + refObject.form + '&returnUrl=' + refObject.returnUrl + '&mac=' + hmac);"
 ```
 
 _Please ensure that the object keys/params are in the order as given in the example above._
@@ -172,11 +175,12 @@ This will output a ready-to-use link with the HMAC for the given message, which 
 Example:
 
 ```bash
-node -e "const { createHmac } = require('node:crypto'); const { Buffer } = require('node:buffer'); const algorithm = 'sha256'; const key = 'skeletonKey'; const refObject = {form: Buffer.from('Fake Form', 'utf8').toString('base64'), returnUrl: Buffer.from('https://www.fake-service.homeoffice.gov.uk', 'utf8').toString('base64')}; const message = JSON.stringify(refObject); const encoding = 'hex'; const hmac = createHmac(algorithm, key).update(message).digest(encoding); console.log('https://hof-feedback.homeoffice.gov.uk?form=' + refObject.form + '&returnUrl=' + refObject.returnUrl + '&mac=' + hmac);"
+node -e "const { createHmac } = require('node:crypto'); const { Buffer } = require('node:buffer'); const algorithm = 'sha256'; const key = 'skeletonKey'; const refObject = {form: Buffer.from('Fake Form', 'utf8').toString('hex'), returnUrl: Buffer.from('https://www.fake-service.homeoffice.gov.uk', 'utf8').toString('hex')}; const message = JSON.stringify(refObject); const encoding = 'hex'; const hmac = createHmac(algorithm, key).update(message).digest(encoding); console.log('https://hof-feedback.homeoffice.gov.uk?form=' + refObject.form + '&returnUrl=' + refObject.returnUrl + '&mac=' + hmac);"
 ```
+
 Expected output:
 
 ```bash
-https://hof-feedback.homeoffice.gov.uk?form=RmFrZSBGb3Jt&returnUrl=aHR0cHM6Ly93d3cuZmFrZS1zZXJ2aWNlLmhvbWVvZmZpY2UuZ292LnVr&mac=32a913dc951a771f7b8b8ac4e12db6cb615850fb23ac7cfc65d8ae06e62b5577
+https://hof-feedback.homeoffice.gov.uk?form=46616b6520466f726d&returnUrl=68747470733a2f2f7777772e66616b652d736572766963652e686f6d656f66666963652e676f762e756b&mac=ab0c7700775d6bcc9a2438b967cc0623c35943b3d9bf50808eedd86b05c673a3
 
 ```

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ Add some `feedback` values to your `config.js`:
 {
   feedback: {
     url: 'https://hof-feedback.homeoffice.gov.uk', // required if you want a feedback banner and link to feedback form
-    form: Buffer.from('<FORM>', 'utf-8').toString('hex'), // hex encode your form name if you want to include this context in the feedback notification email
-    returnUrl: Buffer.from('<RETURN URL>', 'utf-8').toString('hex'), // hex encode a URL if you want a link back to your form included in the feedback email
+    form: Buffer.from('<FORM>', 'utf8').toString('hex'), // hex encode your form name if you want to include this context in the feedback notification email
+    returnUrl: Buffer.from('<RETURN URL>', 'utf8').toString('hex'), // hex encode a URL if you want a link back to your form included in the feedback email
     mac: 'pre-hashed mac of the above two params in a JSON object string' // required if you add one or both of form and returnUrl
   }
 }
@@ -114,9 +114,9 @@ res.locals.feedbackUrl = `${url}?form=${form}&returnUrl=${returnUrl}&mac=${mac}`
 
 Add and remove the query values from the above assignation as required.
 
-You can simply assign `config.feedback.url` to `res.locals.feedbackUrl` if you have no need to supply additional query context.
+Alternatively, the entire link can be generated and added as `config.feedback.url` with or without additional query context - See more in [Generating HMAC and Constructing URL](#generating-hmac-and-constructing-url)
 
-### Query parameters.
+### Query parameters
 
 When linking to this feedback form from other HOF forms you can add query context.
 
@@ -141,13 +141,13 @@ Including these parameters in links to this form is optional, but may improve th
 To have your query parameters trusted by this application, the `form` and `returnUrl` parameters need to be hex encoded. Additionally, the query parameters must be signed by an HMAC that is then appended to the query string as 'mac'. e.g.
 
 ```bash
-https://hof-feedback.homeoffice.gov.uk?form=ASC&returnUrl=https://www.asc.homeoffice.gov.uk
+https://hof-feedback.homeoffice.gov.uk?form=FakeForm&returnUrl=https://www.fake-service.homeoffice.gov.uk
 ```
 
 must become
 
 ```bash
-https://hof-feedback.homeoffice.gov.uk?form=QVND&returnUrl=aHR0cHM6Ly93d3cuYXNjLmhvbWVvZmZpY2UuZ292LnVr&mac=a9c42638a509cfa379e6bc2050e4ecea67b0b30f6706858772a13a5292951a66
+https://hof-feedback.homeoffice.gov.uk?form=46616b65466f726d&returnUrl=68747470733a2f2f7777772e66616b652d736572766963652e686f6d656f66666963652e676f762e756b&mac=6d227b0cd8c368ab1aec2ffd899811f3e3cccc2566cfa934191f4b4311fd9177
 ```
 
 The 'mac' parameter is generated as below from a hash of a JSON object string, a secret key and some settings for hashing algorithm and output encoding. The defaults are SHA256 hashing and hex encoding.

--- a/apps/hff/behaviours/get-service-query.js
+++ b/apps/hff/behaviours/get-service-query.js
@@ -10,19 +10,19 @@ module.exports = superclass => class extends superclass {
       return super.process(req, res, next);
     }
 
-    const { form: formHex, returnUrl: returnUrlHex, mac } = req.query;
+    const { form: encodedForm, returnUrl: encodedReturnUrl, mac } = req.query;
 
     if (!macPatternRegex.test(mac)) {
       req.log('warn', 'MAC query parameter is not valid');
       return super.process(req, res, next);
     }
 
-    if (formHex && !hexPatternRegex.test(formHex)) {
+    if (encodedForm && !hexPatternRegex.test(encodedForm)) {
       req.log('warn', 'Form query parameter is not valid hex encoding');
       return super.process(req, res, next);
     }
 
-    if (returnUrlHex && !hexPatternRegex.test(returnUrlHex)) {
+    if (encodedReturnUrl && !hexPatternRegex.test(encodedReturnUrl)) {
       req.log('warn', 'ReturnURL query parameter is not valid hex encoding');
       return super.process(req, res, next);
     }
@@ -30,12 +30,12 @@ module.exports = superclass => class extends superclass {
     try {
       const comparisonObject = {};
 
-      if (formHex) {
-        comparisonObject.form = formHex;
+      if (encodedForm) {
+        comparisonObject.form = encodedForm;
       }
 
-      if (returnUrlHex) {
-        comparisonObject.returnUrl = returnUrlHex;
+      if (encodedReturnUrl) {
+        comparisonObject.returnUrl = encodedReturnUrl;
       }
 
       const comparisonString = JSON.stringify(comparisonObject);
@@ -43,8 +43,8 @@ module.exports = superclass => class extends superclass {
 
       if (mac === hashedAndHexed) {
         req.log('info', 'HMAC matched OK');
-        const decodedForm = hexDecode(formHex);
-        const decodedReturnUrl = hexDecode(returnUrlHex);
+        const decodedForm = hexDecode(encodedForm);
+        const decodedReturnUrl = hexDecode(encodedReturnUrl);
 
         if (decodedForm && serviceReferrerNameRegex.test(decodedForm)) {
           req.sessionModel.set('service-referrer-name', decodedForm);

--- a/config.js
+++ b/config.js
@@ -21,7 +21,7 @@ module.exports = {
   },
   regex: {
     serviceReferrerName: /^[\w\s\-]*$/,
-    base64Pattern: /^[A-Za-z0-9+/=]+$/,
+    hexPattern: /^[a-fA-F0-9]+$/,
     macPattern: /^[a-fA-F0-9]{64}$/
   }
 };

--- a/test/unit/behaviours/get-service-query.test.js
+++ b/test/unit/behaviours/get-service-query.test.js
@@ -16,7 +16,7 @@ describe('get-service-query behaviour', () => {
   });
 
   class Base {
-    configure() {}
+    process() {}
   }
 
   let req;
@@ -32,11 +32,11 @@ describe('get-service-query behaviour', () => {
 
     GetServiceQuery = Behaviour(Base);
     instance = new GetServiceQuery;
-    Base.prototype.configure = jest.fn().mockReturnValue(req, res, next);
+    Base.prototype.process = jest.fn().mockReturnValue(req, res, next);
   });
 
 
-  describe('The \'configure\' method', () => {
+  describe('The \'process\' method', () => {
     beforeEach(() => {
       req.query = {
         // 'ASC' in hex
@@ -53,12 +53,12 @@ describe('get-service-query behaviour', () => {
     });
 
     test('should be called', () => {
-      instance.configure(req, res, next);
-      expect(Base.prototype.configure).toHaveBeenCalled();
+      instance.process(req, res, next);
+      expect(Base.prototype.process).toHaveBeenCalled();
     });
 
     test('adds req.query values to the session under correct keys and values', () => {
-      instance.configure(req, res, next);
+      instance.process(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe('ASC');
       expect(req.sessionModel.get('service-referrer-url')).toBe('https://www.fake-service.homeoffice.gov.uk');
       expect(utils.createHmacDigest).toHaveBeenCalledWith(
@@ -72,21 +72,21 @@ describe('get-service-query behaviour', () => {
     test('adds form values containing spaces to sessionModel', () => {
       // 'new form' in hex
       req.query.form = '6e657720666f726d';
-      instance.configure(req, res, next);
+      instance.process(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe('new form');
     });
 
     test('does not add a service name query value to session if it does not match the proper format', () => {
       // 'ASC!' in hex
       req.query.form = '41534321';
-      instance.configure(req, res, next);
+      instance.process(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe(undefined);
     });
 
     test('does not add a returnUrl query value to session if it does not match the proper format', () => {
       // 'fake-service.homeoffice.gov.uk' in hex
       req.query.returnUrl = '66616b652d736572766963652e686f6d656f66666963652e676f762e756b';
-      instance.configure(req, res, next);
+      instance.process(req, res, next);
       expect(req.sessionModel.get('service-referrer-url')).toBe(undefined);
     });
 
@@ -98,7 +98,7 @@ describe('get-service-query behaviour', () => {
         returnUrl: '68747470733a2f2f7777772e66616b652d736572766963652e686f6d656f66666963652e676f762e756b',
         mac: '786173686564616e6468657865640b'
       };
-      instance.configure(req, res, next);
+      instance.process(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe(undefined);
       expect(req.sessionModel.get('service-referrer-url')).toBe(undefined);
     });
@@ -110,7 +110,7 @@ describe('get-service-query behaviour', () => {
         // 'https://www.fake-service.homeoffice.gov.uk' in hex
         returnUrl: '68747470733a2f2f7777772e66616b652d736572766963652e686f6d656f66666963652e676f762e756b'
       };
-      instance.configure(req, res, next);
+      instance.process(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe(undefined);
       expect(req.sessionModel.get('service-referrer-url')).toBe(undefined);
       expect(utils.createHmacDigest).not.toHaveBeenCalled();
@@ -120,8 +120,8 @@ describe('get-service-query behaviour', () => {
       utils.createHmacDigest.mockImplementation(() => {
         throw new Error('Test error');
       });
-      instance.configure(req, res, next);
-      expect(Base.prototype.configure).toHaveReturned();
+      instance.process(req, res, next);
+      expect(Base.prototype.process).toHaveReturned();
     });
   });
 
@@ -137,7 +137,7 @@ describe('get-service-query behaviour', () => {
     });
 
     test('returns early and does not attempt to create digest or store values', () => {
-      instance.configure(req, res, next);
+      instance.process(req, res, next);
       expect(req.sessionModel.get('service-referrer-name')).toBe(undefined);
       expect(req.sessionModel.get('service-referrer-url')).toBe(undefined);
       expect(utils.createHmacDigest).not.toHaveBeenCalled();

--- a/utils/index.js
+++ b/utils/index.js
@@ -27,6 +27,8 @@ const createHmacDigest = (algorithm, key, message, encoding) => {
   return createHmac(algorithm, key).update(message).digest(encoding);
 };
 
-const base64Decode = data => Buffer.from(data, 'base64').toString('utf-8');
+const hexDecode = data => {
+  return data ? Buffer.from(data, 'hex').toString('utf-8') : undefined;
+};
 
-module.exports = { getLabel, createHmacDigest, base64Decode};
+module.exports = { getLabel, createHmacDigest, hexDecode };

--- a/utils/index.js
+++ b/utils/index.js
@@ -28,7 +28,7 @@ const createHmacDigest = (algorithm, key, message, encoding) => {
 };
 
 const hexDecode = data => {
-  return data ? Buffer.from(data, 'hex').toString('utf-8') : undefined;
+  return data ? Buffer.from(data, 'hex').toString('utf8') : undefined;
 };
 
 module.exports = { getLabel, createHmacDigest, hexDecode };


### PR DESCRIPTION
## What?

[TLF-305](https://collaboration.homeoffice.gov.uk/jira/browse/TLF-305)
Update the app to support query parameters that are hex encoded rather than base64

## Why?

Naxsi rules were still being triggered after the utf-8 params were encoded to base64 - this is due to the presence of `==` symbols in the base64 (created as a buffer for length when the bytes do not add up to a multiple of 3). In certain presumably rare scenarios the Nginx proxy/Naxsi picks this up as an attempt at scripting.

## How?

Instructions for URL creation with query params are updated to create URLs whose params are hex encoded. The app is updated to process params that are hex encoded.

## Testing?

Tested locally for no params, form param only and form and return URL params added.
Lint and unit tests passing.

## Screenshots (optional)

## Anything Else? (optional)

* Updated the extended method in `get-service-query` behaviour to use `process()` instead of `configure()`. This will stop the processing happening on both GET and POST of the form.
* Removed a couple of unit tests that were basically duplicates or no longer needed

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [x] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
