### PR TITLE
HFF-41: Update accessibility statement

### DIFF
--- a/apps/hff/index.js
+++ b/apps/hff/index.js
@@ -18,5 +18,8 @@ module.exports = {
     },
     '/session-timeout': {},
     '/exit': {}
+  },
+  pages: {
+    '/accessibility': 'static/accessibility'
   }
 };

--- a/apps/hff/translations/src/en/pages.json
+++ b/apps/hff/translations/src/en/pages.json
@@ -9,5 +9,8 @@
     "header": "Feedback sent",
     "intro": "Thank you for your feedback.",
     "link-text": "Return to the GOV.UK homepage"
+  },
+  "accessibility": {
+    "header": "Accessibility statement for this Home Office Forms Application"
   }
 }

--- a/apps/hff/views/content/en/accessibility.md
+++ b/apps/hff/views/content/en/accessibility.md
@@ -1,0 +1,34 @@
+This website is run by the Home Office. We want as many people as possible to be able to use this website. For example, that means you should be able to:
+
+- change colours, contrast levels and fonts
+- zoom in up to 300% without the text spilling off the screen
+- navigate most of the website using just a keyboard
+- navigate most of the website using speech recognition software
+- listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+
+We've also made the website text as simple as possible to understand. [AbilityNet](https://mcmw.abilitynet.org.uk) has advice on making your device easier to use if you have a disability.
+
+## Reporting accessibility problems with this website
+We're always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we're not meeting accessibility requirements, contact:
+
+- Email: <a href ="mailto:hof-accessibility@digital.homeoffice.gov.uk">hof-accessibility@digital.homeoffice.gov.uk</a>
+
+[Read tips on contacting organisations about inaccessible websites](https://www.w3.org/WAI/teach-advocate/contact-inaccessible-websites).
+
+## Enforcement procedure
+The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations'). If you're not happy with how we respond to your complaint, [contact the Equality Advisory and Support Service (EASS)](https://www.equalityadvisoryservice.com).
+
+If you are in Northern Ireland and are not happy with how we respond to your complaint you can contact the Equalities Commission for Northern Ireland who are responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations') in Northern Ireland.
+
+## Technical information about this website's accessibility
+The Home Office is committed to making its website accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018.
+
+## Compliance status
+This website is fully compliant with the [Web Content Accessibility Guidelines version 2.2](https://www.w3.org/TR/WCAG22) AA standard.
+
+## Preparation of this accessibility statement
+This statement was prepared on 01 June 2020. It was last reviewed on 05 March 2025.
+
+This website was last tested on 13 August 2021. The test was carried out internally by the Home Office.
+
+We tested the service based on a user's ability to complete key journeys. All parts of the chosen journeys were tested, including documents. Journeys were chosen on a number of factors including usage statistics, risk assessments and subject matter.

--- a/apps/hff/views/static/accessibility.html
+++ b/apps/hff/views/static/accessibility.html
@@ -1,0 +1,10 @@
+{{<partials-page}}
+  {{$pageTitle}}
+    {{#t}}pages.accessibility{{/t}} &ndash; GOV.UK
+  {{/pageTitle}}
+  {{$page-content}}
+
+    <h1 class="govuk-heading-l">{{#t}}pages.accessibility{{/t}}</h1> 
+    {{#markdown}}accessibility{{/markdown}}
+  {{/page-content}}
+{{/partials-page}}

--- a/hof.settings.json
+++ b/hof.settings.json
@@ -12,6 +12,6 @@
   "session": {
     "name": "hff.hof.sid"
   },
-  "getAccessibility": true,
+  "getAccessibility": false,
   "emailerFallback": true
 }


### PR DESCRIPTION
## What?
Created and wired up new accessibility page for service

## Why?
https://collaboration.homeoffice.gov.uk/jira/browse/HFF-41

## How?
- created accessibility page and content (accessibility.html, accessibility.md)
- added route for accessibility.html (index.html)
- added header for accessibility page (pages.json)
- turned off inheriting default accessibility page (hof.settings.json)

## Testing?
- a user visiting `.../accessibility.html` should be be greeted with an accessibility statement that says it is fully compliant with WCAG v2.2.  Full accessibility statement for comparison available at [link](https://collaboration.homeoffice.gov.uk/jira/browse/HFF-41) above

## Screenshots (optional)
<img width="804" alt="image" src="https://github.com/user-attachments/assets/2a9cace1-8e4d-43da-a3d6-5ae3f8b762d6" />

## Anything Else? (optional)

## Check list

- [X] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [X] I have created a JIRA number for my branch
- [X] I have created a JIRA number for my commit
- [X] Ensure drone builds are green especially tests
- [X] I will squash the commits before merging
