### PR TITLE
HFF-43 Remove HOF reference from cookie banner

### DIFF
--- a/hof.settings.json
+++ b/hof.settings.json
@@ -1,5 +1,5 @@
 {
-  "appName": "HOF feedback form",
+  "appName": "feedback form",
   "theme": "govUK",
   "behaviours": [
     "hof/components/clear-session",


### PR DESCRIPTION
## What? 
[HFF-43](https://collaboration.homeoffice.gov.uk/jira/browse/HFF-43) - Remove 'HOF' from cookie banner
## Why? 
User has no understanding of 'HOF'

## How? 
- Changed app name

## Testing?
Tested on local machine 

## Screenshots (optional)
## Anything Else? (optional)
## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [x] I have followed the chris beams method for my commit https://cbea.ms/git-commit/
here is an [example commit](https://github.com/UKHomeOfficeForms/hof/commit/810959f391187c7c4af6db262bcd143b50093a6e)
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging