### PR TITLE
feat: add helm chart files

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -28,3 +28,4 @@ jest.config.json
 jest.env.js
 sonar-project.properties
 hof-services-config
+charts

--- a/.droneignore
+++ b/.droneignore
@@ -4,3 +4,4 @@ apps/**/translations/**/default.json
 LICENSE.md
 README.md
 CONTRIBUTING.md
+charts

--- a/charts/hff/Chart.yaml
+++ b/charts/hff/Chart.yaml
@@ -1,0 +1,11 @@
+apiVersion: v2
+name: hff-app
+description: A Helm chart for HFF application deployment
+type: application
+version: 1.0.0
+appVersion: "1.0.0"
+keywords:
+  - hff
+  - application
+maintainers:
+  - name: Home Office Digital

--- a/charts/hff/README.md
+++ b/charts/hff/README.md
@@ -1,0 +1,237 @@
+# HFF App Helm Chart
+
+A comprehensive Helm chart for deploying the HFF (Home Office Form Framework) application on Kubernetes, including support for Redis caching, Nginx proxy, ingress, and network policies.
+
+## Overview
+
+This Helm chart packages the HFF application with all its components:
+- **Application Deployment**: Main HFF app with Nginx proxy sidecar
+- **Redis Cache**: Session and data caching
+- **Services**: ClusterIP services for app and Redis
+- **Ingress**: External and internal ingress with TLS support
+- **Network Policies**: Security controls for pod-to-pod communication
+- **ConfigMaps**: Application configuration management
+
+## Chart Structure
+
+```
+./
+├── Chart.yaml                      # Chart metadata
+├── values.yaml                     # Default values
+├── README.md                       # This file
+└── templates/
+    ├── _helpers.tpl               # Template helpers and variables
+    ├── app-deployment.yaml        # Application deployment
+    ├── app-service.yaml           # Application service
+    ├── app-configmap.yaml         # Application configuration
+    ├── app-ingress-external.yaml  # External ingress
+    ├── app-ingress-internal.yaml  # Internal ingress
+    ├── app-networkpolicy-egress.yaml
+    ├── app-networkpolicy-external.yaml
+    ├── app-networkpolicy-internal.yaml
+    ├── redis-deployment.yaml      # Redis deployment
+    ├── redis-service.yaml         # Redis service
+    ├── redis-configmap.yaml       # Redis configuration
+    ├── redis-networkpolicy.yaml   # Redis network policy
+    └── external-secrets.yaml
+```
+
+## Configuration
+
+### Key Parameters
+
+#### Global Settings
+```yaml
+global:
+  namespace: <namespace>
+  environment: <environment>
+```
+
+#### Application
+```yaml
+app:
+  name: <app-name>
+  replicas: 1
+
+image:
+  repository: <image-repository>
+  tag: <image-tag>
+  pullPolicy: Always
+
+nginx:
+  image: <nginx-image>
+  env:
+    - name: <nginx-env-var-name>
+      value: <nginx-env-var-value>
+```
+
+#### Labels
+
+```yaml
+commonLabels:
+  team: platform
+  owner: app-team
+```
+
+Any key/value pairs under `commonLabels` are added to app and redis Deployment metadata labels and pod template labels.
+
+#### Ingress Configuration
+```yaml
+ingress:
+  externalEnabled: true
+  internalEnabled: true
+  external:
+    className: "<external-ingress-class>"
+    host: "<external-hostname>"
+    annotations: {}
+  internal:
+    className: "<internal-ingress-class>"
+    host: "<internal-hostname>"
+    annotations: {}
+```
+
+Set `externalEnabled` and `internalEnabled` according to the ingress endpoints you need.
+When an ingress is enabled, both `className` and `host` are required for that ingress.
+
+#### Redis Configuration
+```yaml
+redis:
+  enabled: true
+  image: <redis-image>
+  port: 6379
+  replicas: 1
+  resources:
+    requests:
+      cpu: "20m"
+      memory: "100Mi"
+    limits:
+      cpu: "100m"
+      memory: "200Mi"
+```
+
+#### Environment Variables
+```yaml
+env:
+  TZ: Europe/London
+  NODE_TLS_REJECT_UNAUTHORIZED: "0"
+  REDIS_PORT: "6379"
+  USE_MOCKS: "false"
+```
+
+#### Required Secret Inputs
+The application expects three Kubernetes Secret references to be provided through values:
+
+```yaml
+secrets:
+  sessionSecret:
+    name: <session-secret-name>
+    key: <session-secret-key>
+  notifyKey:
+    name: <notify-secret-name>
+    key: <notify-secret-key>
+  queryKey:
+    name: <query-secret-name>
+    key: <query-secret-key>
+```
+
+If `externalSecrets.enabled` is used, these secret names/keys are still the inputs the application consumes.
+
+For External Secrets integration, each secret entry can also include:
+
+```yaml
+secrets:
+  sessionSecret:
+    remoteKey: <remote-secret-name-or-path>
+    remoteProperty: <optional-property-name>
+```
+
+- `remoteKey` is the upstream secret name/path in the external provider; when set, an `ExternalSecret` is rendered for that entry.
+- `remoteProperty` is used to select a specific field from the upstream secret referenced by `remoteKey`.
+
+The External Secrets store reference is configured separately:
+
+```yaml
+externalSecrets:
+  enabled: true
+  secretStoreRef:
+    name: <secret-store-name>
+    kind: SecretStore
+```
+
+`secretStoreRef` points to an existing `SecretStore` (or `ClusterSecretStore`) resource where provider details (for example AWS Secrets Manager region/auth) are defined.
+
+## Customization
+
+### Custom ConfigMap Values
+
+Add application-specific configuration in `values.yaml`:
+
+```yaml
+configMap:
+  data:
+    APP_SETTING_1: "value1"
+    APP_SETTING_2: "value2"
+    REDIS_CLUSTER: "<redis-service-fqdn>"
+```
+
+### Custom Resource Limits
+
+```yaml
+resources:
+  app:
+    requests:
+      cpu: "50m"
+      memory: "256Mi"
+    limits:
+      cpu: "500m"
+      memory: "512Mi"
+  nginx:
+    requests:
+      cpu: "20m"
+      memory: "64Mi"
+    limits:
+      cpu: "200m"
+      memory: "256Mi"
+```
+
+## Health Checks
+
+Health checks are enabled by default:
+
+```yaml
+healthChecks:
+  enabled: true
+  liveness:
+    path: /healthz/ping
+    initialDelaySeconds: 10
+    periodSeconds: 10
+  readiness:
+    path: /healthz/readiness
+    initialDelaySeconds: 15
+    periodSeconds: 5
+```
+
+## Security
+
+### Network Policies
+Network policies restrict traffic to and from the application:
+- External ingress from namespaces labeled `name=ingress-external`
+- Internal ingress from namespaces labeled `name=ingress-internal` and optional CIDRs in `networkPolicies.internalIngressCIDRs`
+- Redis access only from application pods
+
+Enable/disable with:
+```yaml
+networkPolicies:
+  enabled: true
+  externalIngress: true
+  internalIngress: true
+  internalIngressCIDRs: []
+  redisAccess: true
+```
+
+### Security Context
+All containers run as non-root:
+```yaml
+securityContext:
+  runAsNonRoot: true
+```

--- a/charts/hff/README.md
+++ b/charts/hff/README.md
@@ -1,6 +1,6 @@
 # HFF App Helm Chart
 
-A comprehensive Helm chart for deploying the HFF (Home Office Form Framework) application on Kubernetes, including support for Redis caching, Nginx proxy, ingress, and network policies.
+A comprehensive Helm chart for deploying the HFF (HOF Feedback Form) application on Kubernetes, including support for Redis caching, Nginx proxy, ingress, and network policies.
 
 ## Overview
 

--- a/charts/hff/templates/_helpers.tpl
+++ b/charts/hff/templates/_helpers.tpl
@@ -1,0 +1,135 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "hff-app.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+*/}}
+{{- define "hff-app.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "hff-app.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.AppVersion | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "hff-app.labels" -}}
+helm.sh/chart: {{ include "hff-app.chart" . }}
+{{ include "hff-app.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+User-provided labels excluding keys managed by chart selectors.
+*/}}
+{{- define "hff-app.commonLabels" -}}
+{{- range $k := keys .Values.commonLabels | sortAlpha }}
+{{- if and (ne $k "app.kubernetes.io/name") (ne $k "app.kubernetes.io/instance") }}
+{{- $v := index $.Values.commonLabels $k }}
+{{ $k }}: {{ $v | quote }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "hff-app.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "hff-app.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Redis selector labels
+*/}}
+{{- define "hff-app.redis.selectorLabels" -}}
+app.kubernetes.io/name: redis
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Get app name with branch suffix if applicable
+*/}}
+{{- define "hff-app.appName" -}}
+{{- if .Values.branch.enabled }}
+{{- printf "%s-%s" .Values.app.name .Values.branch.name }}
+{{- else }}
+{{- .Values.app.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get Redis name with branch suffix if applicable
+*/}}
+{{- define "hff-app.redis.name" -}}
+{{- if .Values.branch.enabled }}
+{{- printf "redis-%s" .Values.branch.name }}
+{{- else }}
+{{- .Values.redis.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get the environment type (prod, uat, dev, branch)
+*/}}
+{{- define "hff-app.envType" -}}
+{{- if .Values.branch.enabled }}
+branch
+{{- else }}
+{{- .Values.global.environment }}
+{{- end }}
+{{- end }}
+
+{{/*
+Determine if health checks should be enabled
+*/}}
+{{- define "hff-app.healthChecks.enabled" -}}
+{{- if .Values.branch.enabled }}
+false
+{{- else }}
+{{- .Values.healthChecks.enabled }}
+{{- end }}
+{{- end }}
+
+{{/*
+Get replica count based on environment
+*/}}
+{{- define "hff-app.replicas" -}}
+{{- if eq .Values.global.environment "prod" }}
+2
+{{- else }}
+1
+{{- end }}
+{{- end }}
+
+{{/*
+Get ConfigMap name with branch suffix if applicable
+*/}}
+{{- define "hff-app.configMapName" -}}
+{{- if .Values.branch.enabled }}
+{{- printf "%s-configmap-%s" .Values.app.name .Values.branch.name }}
+{{- else }}
+{{- printf "%s-configmap" .Values.app.name }}
+{{- end }}
+{{- end }}

--- a/charts/hff/templates/app-configmap.yaml
+++ b/charts/hff/templates/app-configmap.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.configMap.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.app.name }}-configmap
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: hff-app
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  {{- if .Values.configMap.data }}
+  {{- toYaml .Values.configMap.data | nindent 2 }}
+  {{- else }}
+  PLACEHOLDER: "true"
+  {{- end }}
+{{- end }}

--- a/charts/hff/templates/app-deployment.yaml
+++ b/charts/hff/templates/app-deployment.yaml
@@ -1,0 +1,114 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ required "app.name is required" .Values.app.name }}
+  namespace: {{ required "global.namespace is required" .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: hff-app
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "hff-app.commonLabels" . | nindent 4 }}
+    
+spec:
+  replicas: {{ .Values.app.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hff-app
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        name: {{ required "app.name is required" .Values.app.name }}
+        app.kubernetes.io/name: hff-app
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "hff-app.commonLabels" . | nindent 8 }}
+        app: {{ required "app.name is required" .Values.app.name }}
+        service: {{ required "app.name is required" .Values.app.name }}
+    spec:
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      containers:
+      - name: {{ required "app.name is required" .Values.app.name }}
+        image: "{{ required "image.repository is required" .Values.image.repository }}:{{ required "image.tag is required" .Values.image.tag }}"
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.command }}
+        command:
+          {{- toYaml .Values.command | nindent 10 }}
+        {{- end }}
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        ports:
+        - containerPort: {{ .Values.containerPorts.app }}
+          name: app
+        envFrom:
+        - configMapRef:
+            name: {{ required "app.name is required" .Values.app.name }}-configmap
+        env:
+        - name: TZ
+          value: {{ .Values.env.TZ }}
+        - name: NODE_TLS_REJECT_UNAUTHORIZED
+          value: {{ .Values.env.NODE_TLS_REJECT_UNAUTHORIZED | quote }}
+        - name: REDIS_PORT
+          value: {{ .Values.env.REDIS_PORT | quote }}
+        - name: REDIS_HOST
+          value: {{ .Values.redis.name }}
+        - name: SESSION_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "secrets.sessionSecret.name is required" .Values.secrets.sessionSecret.name }}
+              key: {{ required "secrets.sessionSecret.key is required" .Values.secrets.sessionSecret.key }}
+        - name: NOTIFY_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "secrets.notifyKey.name is required" .Values.secrets.notifyKey.name }}
+              key: {{ required "secrets.notifyKey.key is required" .Values.secrets.notifyKey.key }}
+        - name: QUERY_KEY
+          valueFrom:
+            secretKeyRef:
+              name: {{ required "secrets.queryKey.name is required" .Values.secrets.queryKey.name }}
+              key: {{ required "secrets.queryKey.key is required" .Values.secrets.queryKey.key }}
+        - name: USE_MOCKS
+          value: {{ .Values.env.USE_MOCKS | quote }}
+        {{- if .Values.healthChecks.enabled }}
+        livenessProbe:
+          httpGet:
+            path: {{ .Values.healthChecks.liveness.path }}
+            port: {{ .Values.containerPorts.app }}
+          initialDelaySeconds: {{ .Values.healthChecks.liveness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.healthChecks.liveness.periodSeconds }}
+        readinessProbe:
+          httpGet:
+            path: {{ .Values.healthChecks.readiness.path }}
+            port: {{ .Values.containerPorts.app }}
+          initialDelaySeconds: {{ .Values.healthChecks.readiness.initialDelaySeconds }}
+          periodSeconds: {{ .Values.healthChecks.readiness.periodSeconds }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources.app | nindent 10 }}
+        volumeMounts:
+        - mountPath: /public
+          name: public
+
+      - name: nginx-proxy
+        image: {{ required "nginx.image is required" .Values.nginx.image }}
+        {{- if .Values.nginx.env }}
+        env:
+          {{- toYaml .Values.nginx.env | nindent 10 }}
+        {{- end }}
+        resources:
+          {{- toYaml .Values.resources.nginx | nindent 10 }}
+        ports:
+        - containerPort: {{ .Values.containerPorts.nginx }}
+          name: https
+        volumeMounts:
+        - mountPath: /public
+          name: public
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+      volumes:
+      - name: public
+        emptyDir: {}

--- a/charts/hff/templates/app-ingress-external.yaml
+++ b/charts/hff/templates/app-ingress-external.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.ingress.externalEnabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ required "app.name is required" .Values.app.name }}-external
+  namespace: {{ required "global.namespace is required" .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: hff-app
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.ingress.external.annotations }}
+  annotations:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  ingressClassName: {{ required "ingress.external.className is required" .Values.ingress.external.className }}
+  rules:
+  - host: {{ required "ingress.external.host is required" .Values.ingress.external.host }}
+    http:
+      paths:
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ required "app.name is required" .Values.app.name }}
+            port:
+              number: {{ .Values.service.ports.https }}
+{{- end }}

--- a/charts/hff/templates/app-ingress-internal.yaml
+++ b/charts/hff/templates/app-ingress-internal.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.ingress.internalEnabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ required "app.name is required" .Values.app.name }}-internal
+  namespace: {{ required "global.namespace is required" .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: hff-app
+    app.kubernetes.io/instance: {{ .Release.Name }}
+{{- with .Values.ingress.internal.annotations }}
+  annotations:
+{{- toYaml . | nindent 4 }}
+{{- end }}
+spec:
+  ingressClassName: {{ required "ingress.internal.className is required" .Values.ingress.internal.className }}
+  rules:
+  - host: {{ required "ingress.internal.host is required" .Values.ingress.internal.host }}
+    http:
+      paths:
+      - path: "/"
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ required "app.name is required" .Values.app.name }}
+            port:
+              number: {{ .Values.service.ports.https }}
+{{- end }}

--- a/charts/hff/templates/app-networkpolicy-egress.yaml
+++ b/charts/hff/templates/app-networkpolicy-egress.yaml
@@ -1,0 +1,53 @@
+{{- if and .Values.networkPolicies.enabled .Values.networkPolicies.egress.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: app-networkpolicy-egress-{{ .Values.app.name }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: hff-app
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      name: {{ .Values.app.name }}
+  policyTypes:
+  - Egress
+  egress:
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  - to:
+    - podSelector:
+        matchLabels:
+          name: {{ .Values.redis.name }}
+    ports:
+    - protocol: TCP
+      port: {{ .Values.redis.port }}
+  {{- range .Values.networkPolicies.egress.redisServiceCIDRs }}
+  - to:
+    - ipBlock:
+        cidr: {{ . }}
+    ports:
+    - protocol: TCP
+      port: {{ $.Values.redis.port }}
+  {{- end }}
+  {{- range .Values.networkPolicies.egress.externalHttpsCIDRs }}
+  - to:
+    - ipBlock:
+        cidr: {{ . }}
+    ports:
+    - protocol: TCP
+      port: 443
+  {{- end }}
+{{- end }}

--- a/charts/hff/templates/app-networkpolicy-external.yaml
+++ b/charts/hff/templates/app-networkpolicy-external.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.networkPolicies.enabled }}
+{{- if .Values.networkPolicies.externalIngress }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-network-policy-external-{{ .Values.app.name }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: hff-app
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      name: {{ .Values.app.name }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: ingress-external
+    ports:
+    - port: {{ .Values.containerPorts.app }}
+      protocol: TCP
+    - port: {{ .Values.containerPorts.nginx }}
+      protocol: TCP
+{{- end }}
+{{- end }}

--- a/charts/hff/templates/app-networkpolicy-internal.yaml
+++ b/charts/hff/templates/app-networkpolicy-internal.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.networkPolicies.enabled }}
+{{- if .Values.networkPolicies.internalIngress }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: ingress-network-policy-internal-{{ .Values.app.name }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: hff-app
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      name: {{ .Values.app.name }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: ingress-internal
+    {{ range .Values.networkPolicies.internalIngressCIDRs }}
+    - ipBlock:
+        cidr: {{ . | quote }}
+    {{ end }}
+    ports:
+    - port: {{ .Values.containerPorts.app }}
+      protocol: TCP
+    - port: {{ .Values.containerPorts.nginx }}
+      protocol: TCP
+{{- end }}
+{{- end }}

--- a/charts/hff/templates/app-service.yaml
+++ b/charts/hff/templates/app-service.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.app.name }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: hff-app
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  selector:
+    app.kubernetes.io/name: hff-app
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  type: {{ .Values.service.type }}
+  ports:
+  - name: http
+    port: {{ .Values.service.ports.http }}
+    targetPort: {{ .Values.containerPorts.app }}
+  - name: https
+    port: {{ .Values.service.ports.https }}
+    targetPort: {{ .Values.containerPorts.nginx }}

--- a/charts/hff/templates/external-secrets.yaml
+++ b/charts/hff/templates/external-secrets.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.externalSecrets.enabled }}
+{{- range $secretName, $secret := .Values.secrets }}
+{{- if $secret.remoteKey }}
+---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: {{ $secret.name }}
+  namespace: {{ $.Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: hff-app
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+spec:
+  refreshInterval: {{ $.Values.externalSecrets.refreshInterval }}
+  secretStoreRef:
+    name: {{ required "externalSecrets.secretStoreRef.name is required when externalSecrets.enabled=true" $.Values.externalSecrets.secretStoreRef.name }}
+    kind: {{ $.Values.externalSecrets.secretStoreRef.kind }}
+  target:
+    name: {{ $secret.name }}
+    creationPolicy: Owner
+  data:
+  - secretKey: {{ $secret.key }}
+    remoteRef:
+      key: {{ $secret.remoteKey }}
+      {{- if $secret.remoteProperty }}
+      property: {{ $secret.remoteProperty }}
+      {{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/charts/hff/templates/redis-configmap.yaml
+++ b/charts/hff/templates/redis-configmap.yaml
@@ -1,0 +1,38 @@
+{{- if .Values.redis.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: redis-cache-config
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+data:
+  redis-config: |
+    # Redis configuration file
+    # For detailed documentation, see https://redis.io/documentation
+
+    # Network configuration
+    bind 0.0.0.0
+    port {{ .Values.redis.port }}
+
+    # Memory management
+    maxmemory 256mb
+    maxmemory-policy allkeys-lru
+
+    # Persistence (disabled for session cache)
+    save ""
+    appendonly no
+
+    # Logging
+    loglevel notice
+    logfile ""
+
+    # Database selection
+    databases 16
+
+    # Other settings
+    tcp-keepalive 300
+    timeout 0
+{{- end }}

--- a/charts/hff/templates/redis-deployment.yaml
+++ b/charts/hff/templates/redis-deployment.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.redis.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.redis.name }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "hff-app.commonLabels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.redis.replicas }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/instance: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.redis.name }}
+        service: {{ .Values.redis.name }}
+        app.kubernetes.io/name: redis
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        {{- include "hff-app.commonLabels" . | nindent 8 }}
+    spec:
+      {{- if .Values.tolerations }}
+      tolerations:
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      securityContext:
+        {{- toYaml .Values.securityContext | nindent 8 }}
+      containers:
+      - name: redis
+        image: {{ required "redis.image is required when redis.enabled=true" .Values.redis.image }}
+        ports:
+        - containerPort: {{ .Values.redis.port }}
+          name: redis
+        volumeMounts:
+        - mountPath: /var/lib/redis
+          name: data
+        - mountPath: /usr/local/etc/redis
+          name: redis-config
+        securityContext:
+          {{- toYaml .Values.securityContext | nindent 10 }}
+        resources:
+          {{- toYaml .Values.redis.resources | nindent 10 }}
+      volumes:
+      - name: data
+        emptyDir: {}
+      - name: redis-config
+        configMap:
+          name: redis-cache-config
+{{- end }}

--- a/charts/hff/templates/redis-networkpolicy.yaml
+++ b/charts/hff/templates/redis-networkpolicy.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.networkPolicies.enabled }}
+{{- if .Values.networkPolicies.redisAccess }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-permit-access-{{ .Values.app.name }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: hff-app
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  podSelector:
+    matchLabels:
+      name: {{ .Values.redis.name }}
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - podSelector:
+        matchLabels:
+          name: {{ .Values.app.name }}
+    ports:
+    - port: {{ .Values.redis.port }}
+      protocol: TCP
+{{- end }}
+{{- end }}

--- a/charts/hff/templates/redis-service.yaml
+++ b/charts/hff/templates/redis-service.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.redis.enabled }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.redis.name }}
+  namespace: {{ .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    name: {{ .Values.redis.name }}
+    service: {{ .Values.redis.name }}
+spec:
+  selector:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: {{ .Release.Name }}
+  ports:
+  - port: {{ .Values.redis.port }}
+    targetPort: {{ .Values.redis.port }}
+    protocol: TCP
+    name: redis
+{{- end }}

--- a/charts/hff/values.yaml
+++ b/charts/hff/values.yaml
@@ -1,0 +1,150 @@
+# Default values for hff-app Helm chart
+
+# Global settings
+global:
+  namespace: ""
+  environment: ""
+
+# Application configuration
+app:
+  name: ""
+  replicas: 1
+
+# Optional additional labels applied to app and redis resources
+commonLabels: {}
+
+# Image configuration
+image:
+  repository: ""
+  tag: ""
+  pullPolicy: Always
+
+# Container ports
+containerPorts:
+  app: 8080
+  nginx: 10443
+
+# Service configuration
+service:
+  type: ClusterIP
+  ports:
+    http: 10080
+    https: 10443
+
+# Ingress configuration
+ingress:
+  externalEnabled: false
+  internalEnabled: false
+  external:
+    className: ""
+    host: ""
+    annotations: {}
+  internal:
+    className: ""
+    host: ""
+    annotations: {}
+
+# Application environment variables
+env:
+  TZ: Europe/London
+  NODE_TLS_REJECT_UNAUTHORIZED: "0"
+  REDIS_PORT: "6379"
+  USE_MOCKS: "false"
+
+# Resource requests and limits
+resources:
+  app:
+    requests:
+      cpu: "20m"
+      memory: "100Mi"
+    limits:
+      cpu: "100m"
+      memory: "200Mi"
+  nginx:
+    requests:
+      memory: "10Mi"
+      cpu: "10m"
+    limits:
+      cpu: "250m"
+      memory: "256Mi"
+
+# Nginx proxy configuration
+nginx:
+  image: ""
+
+# Health checks
+healthChecks:
+  enabled: true
+  liveness:
+    initialDelaySeconds: 10
+    periodSeconds: 10
+    path: /healthz/ping
+  readiness:
+    initialDelaySeconds: 15
+    periodSeconds: 5
+    path: /healthz/readiness
+
+# ConfigMap data
+configMap:
+  enabled: true
+  data: {}
+
+# External secrets
+externalSecrets:
+  enabled: false
+  refreshInterval: 1h
+  secretStoreRef:
+    name: ""
+    kind: SecretStore
+
+# Secrets
+secrets:
+  sessionSecret:
+    name: ""
+    key: ""
+    remoteKey: ""
+    remoteProperty: ""
+  notifyKey:
+    name: ""
+    key: ""
+    remoteKey: ""
+    remoteProperty: ""
+  queryKey:
+    name: ""
+    key: ""
+    remoteKey: ""
+    remoteProperty: ""
+
+# Redis configuration
+redis:
+  enabled: true
+  name: redis
+  image: ""
+  port: 6379
+  replicas: 1
+  resources:
+    requests:
+      cpu: "20m"
+      memory: "100Mi"
+    limits:
+      cpu: "100m"
+      memory: "200Mi"
+
+# Network policies
+networkPolicies:
+  enabled: true
+  externalIngress: true
+  internalIngress: true
+  internalIngressCIDRs: []
+  redisAccess: true
+  egress:
+    enabled: true
+    redisServiceCIDRs: []
+    externalHttpsCIDRs: []
+
+# Security context
+securityContext:
+  runAsNonRoot: true
+
+# Pod scheduling overrides
+tolerations: []


### PR DESCRIPTION
This pull request introduces a new Helm chart for deploying the HFF (HOF Feedback Form) application to Kubernetes. It provides a comprehensive and configurable deployment, including support for Redis caching, Nginx proxy, ingress (internal and external), network policies, configuration management, and integration with External Secrets. The chart is modular, with templates for each major component, and is well-documented for ease of use and customization.

The most important changes are:

**Helm Chart Structure and Metadata**
- Added a new Helm chart for the HFF application, including `Chart.yaml` with metadata and maintainers, and a detailed `README.md` describing chart structure, configuration options, and customization guidance. [[1]](diffhunk://#diff-6f29ec9beb8c992276d1e699b81251c35c39258308eed3ef40941dad36c023f9R1-R11) [[2]](diffhunk://#diff-1a4b7de447d0a53b77cde0b0d27e8820e4e7b23dca8398247f5a88189a19dd6bR1-R237)

**Application Deployment and Configuration**
- Implemented `app-deployment.yaml` and `app-service.yaml` templates to deploy the main application with an Nginx sidecar, environment variables, health checks, and resource controls. Also included a `ConfigMap` template for application configuration. [[1]](diffhunk://#diff-98d78db908052f39eda63e695ec3dee5df3684bd352105c7ed3079c0c82c2bd2R1-R114) [[2]](diffhunk://#diff-9c421677f9a390606b8f3bcb91d2942b422b00981b4a7174830cd6a7b83bca10R1-R21) [[3]](diffhunk://#diff-4d4892fd5e3a9b43475b35a6e237f6ae589f0fed56735edb21fbe264c13ca2aaR1-R17)
- Added `_helpers.tpl` with template helpers for naming, labels, replica counts, and environment-specific logic.

**Ingress and Network Security**
- Introduced templates for both external and internal ingress resources, supporting TLS and class/host configuration, as well as multiple network policy templates to restrict pod communication for security. [[1]](diffhunk://#diff-44faefe84049225a368e84e73bae56f285ab5b315989bcbd82fb081e34f6620cR1-R28) [[2]](diffhunk://#diff-f46fa955885fa965dbf26d5b9af05513e67e0958e93c5696109c42e5386230d6R1-R28) [[3]](diffhunk://#diff-04fedd2588ceb07e573bea5314fe640849cc830ad11950aa0276559fa0eacbb9R1-R29) [[4]](diffhunk://#diff-5c96d5da6db887e258db1fbe4ec0f0acf3783bba89d16875268ed1f0d0c7624dR1-R33) [[5]](diffhunk://#diff-c96b730e42bf5b0dd94f1818287d7f0674e82a78d41d3aae6b17520dcdefc9a1R1-R53)

**Redis Integration**
- Provided templates for deploying Redis as a session/data cache, including its own deployment, service, configmap, and network policy to restrict access to only application pods.

**Secrets Management**
- Integrated support for Kubernetes Secrets and External Secrets, allowing secrets to be sourced from external providers and injected into the application via environment variables.

These changes collectively enable a production-ready, secure, and configurable deployment of the HFF application on Kubernetes.## What?

## Why?

## How?

## Testing?

## Screenshots (optional)

## Anything Else? (optional)

## Check list

- [ ] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [ ] Ensure drone builds are green especially tests
- [ ] I will squash the commits before merging
