### PR TITLE
HFF-96: Replace with Final Nginx proxy Image

### DIFF
--- a/kube/app/deployment.yml
+++ b/kube/app/deployment.yml
@@ -111,7 +111,7 @@ spec:
 
         - name: nginx-proxy
           # nginx-proxy-govuk:v4
-          image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/sas/hof-docker-nginx-proxy@sha256:4e5dad407fe0ce3095cde18de18c13b4b6c73df092a35bbcf7b86f52090415bd
+          image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/sas/hof-docker-nginx-proxy@sha256:6dea85005f49b80ffee2668a7b57bbfc561e3ddb4acd2faf25fbd698cfe29eee
           resources:
             requests:
               memory: 10Mi


### PR DESCRIPTION
**WHAT?**
* This is the final image which has been already tested by QA team
* This work is done as part of corecloud migration to ensure the image doesn't have any high, critical vulnerabilty
* Used latest Base image to fix vulnerabilties which ensures we get the newest security patches, updated system libraries, and better upstream compatibility.
* Added apk upgrade to fix the Vulnerabilties, Added a comment to explain the change
* Update Drone Pipeline to add trivy scan steps and cron steps
* Move self-signed cert generation from image build to container startup
* NGINX is usually the first component exposed to clients, so any proxy/TLS/library CVE can be directly targeted.


**WHY?**

* generates certs on container startup instead of image build, which is better for runtime-mounted cert scenarios and avoids baking generated certs into the image.
*  a vulnerable reverse proxy can become the entry point to the whole system, so fixing proxy image CVEs is mandatory, not optional.



**HOW?**

* removed build-time cert creation from Dockerfile
* ensured runtime user owns /etc/keys for cert write access
* Fixed Vulnerabilties




**TESTING?**

* First service to be tested

**ANYTHING ELSE?**




**SCREENSHOT?**

Confirms that cert and keys are not generated during docker build process , trivy scan successfull


exec’d into the running container and verified that the certificate and key files are present under /etc/keys. This confirms they are being generated at container startup by the entrypoint, not baked into the image.



