### PR TITLE
CCL-10172 - implemenet exemption via gh app

### DIFF
--- a/.github/workflows/build-scan-push.yml
+++ b/.github/workflows/build-scan-push.yml
@@ -14,7 +14,7 @@ jobs:
         permissions:
             contents: read
             id-token: write
-        uses: Home-Office-Digital/core-cloud-workflow-docker-actions/.github/workflows/build-scan-push.yml@1.4.0
+        uses: Home-Office-Digital/core-cloud-workflow-docker-actions/.github/workflows/build-scan-push.yml@1.5.0
         with:
             working_directory: "."
             dockerfile: "Dockerfile"
@@ -24,3 +24,5 @@ jobs:
         secrets:
             AWS_ECR_ACCOUNT_ID: ${{ secrets.AWS_ECR_ACCOUNT_ID }}
             ROLE_TO_ASSUME: ${{ secrets.ROLE_TO_ASSUME }}
+            EXEMPTIONS_APP_ID: ${{ secrets.EXEMPTIONS_APP_ID }}
+            EXEMPTIONS_APP_PRIVATE_KEY: ${{ secrets.EXEMPTIONS_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## What?

Updates build-scan-push workflow to version 1.5.0. This implements a Github App to retrieve the CVE exemption.

## Why?

To continue working in this repo

## How?

## Testing?

## Screenshots (optional)

## Anything Else? (optional)

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [ ] I have created a JIRA number for my branch
- [ ] I have created a JIRA number for my commit
- [x] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
