### PR TITLE
feat(CCL-10802): Adding kyverno policy fix for HFF prod deployment

### DIFF
--- a/charts/hff/Chart.yaml
+++ b/charts/hff/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: hff-app
 description: A Helm chart for HFF application deployment
 type: application
-version: 1.0.1
+version: 1.0.2
 appVersion: "1.0.0"
 keywords:
   - hff

--- a/charts/hff/README.md
+++ b/charts/hff/README.md
@@ -211,6 +211,25 @@ healthChecks:
     periodSeconds: 5
 ```
 
+The nginx sidecar and Redis container also use TCP liveness and readiness probes by default. Configure their timings under `nginx.healthChecks` and `redis.healthChecks`.
+
+## Availability
+
+Pod anti-affinity is enabled by default to spread application and Redis replicas across availability zones when possible:
+
+```yaml
+podAntiAffinity:
+  enabled: true
+```
+
+For application deployments with more than one replica, a Pod Disruption Budget is enabled by default:
+
+```yaml
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1
+```
+
 ## Security
 
 ### Network Policies

--- a/charts/hff/templates/app-deployment.yaml
+++ b/charts/hff/templates/app-deployment.yaml
@@ -25,6 +25,18 @@ spec:
         app: {{ required "app.name is required" .Values.app.name }}
         service: {{ required "app.name is required" .Values.app.name }}
     spec:
+      {{- if .Values.podAntiAffinity.enabled }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: hff-app
+                    app.kubernetes.io/instance: {{ .Release.Name }}
+                topologyKey: topology.kubernetes.io/zone
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
@@ -104,6 +116,18 @@ spec:
         ports:
         - containerPort: {{ .Values.containerPorts.nginx }}
           name: https
+        {{- if .Values.nginx.healthChecks.enabled }}
+        livenessProbe:
+          tcpSocket:
+            port: https
+          initialDelaySeconds: {{ .Values.nginx.healthChecks.initialDelaySeconds }}
+          periodSeconds: {{ .Values.nginx.healthChecks.periodSeconds }}
+        readinessProbe:
+          tcpSocket:
+            port: https
+          initialDelaySeconds: {{ .Values.nginx.healthChecks.initialDelaySeconds }}
+          periodSeconds: {{ .Values.nginx.healthChecks.periodSeconds }}
+        {{- end }}
         volumeMounts:
         - mountPath: /public
           name: public

--- a/charts/hff/templates/app-pdb.yaml
+++ b/charts/hff/templates/app-pdb.yaml
@@ -1,0 +1,18 @@
+{{- if and .Values.podDisruptionBudget.enabled (gt (int .Values.app.replicas) 1) }}
+---
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ required "app.name is required" .Values.app.name }}
+  namespace: {{ required "global.namespace is required" .Values.global.namespace }}
+  labels:
+    app.kubernetes.io/name: hff-app
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    {{- include "hff-app.commonLabels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: hff-app
+      app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/hff/templates/redis-deployment.yaml
+++ b/charts/hff/templates/redis-deployment.yaml
@@ -24,6 +24,18 @@ spec:
         app.kubernetes.io/instance: {{ .Release.Name }}
         {{- include "hff-app.commonLabels" . | nindent 8 }}
     spec:
+      {{- if .Values.podAntiAffinity.enabled }}
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: redis
+                    app.kubernetes.io/instance: {{ .Release.Name }}
+                topologyKey: topology.kubernetes.io/zone
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations:
         {{- toYaml .Values.tolerations | nindent 8 }}
@@ -36,6 +48,18 @@ spec:
         ports:
         - containerPort: {{ .Values.redis.port }}
           name: redis
+        {{- if .Values.redis.healthChecks.enabled }}
+        livenessProbe:
+          tcpSocket:
+            port: redis
+          initialDelaySeconds: {{ .Values.redis.healthChecks.initialDelaySeconds }}
+          periodSeconds: {{ .Values.redis.healthChecks.periodSeconds }}
+        readinessProbe:
+          tcpSocket:
+            port: redis
+          initialDelaySeconds: {{ .Values.redis.healthChecks.initialDelaySeconds }}
+          periodSeconds: {{ .Values.redis.healthChecks.periodSeconds }}
+        {{- end }}
         volumeMounts:
         - mountPath: /var/lib/redis
           name: data

--- a/charts/hff/values.yaml
+++ b/charts/hff/values.yaml
@@ -71,6 +71,10 @@ resources:
 # Nginx proxy configuration
 nginx:
   image: ghcr.io/nginxinc/nginx-unprivileged:1.27-alpine
+  healthChecks:
+    enabled: true
+    initialDelaySeconds: 10
+    periodSeconds: 10
 
 # Health checks
 healthChecks:
@@ -122,6 +126,10 @@ redis:
   image: redis:7.2-alpine
   port: 6379
   replicas: 1
+  healthChecks:
+    enabled: true
+    initialDelaySeconds: 5
+    periodSeconds: 10
   resources:
     requests:
       cpu: "20m"
@@ -148,3 +156,12 @@ securityContext:
 
 # Pod scheduling overrides
 tolerations: []
+
+# Spread replicas across availability zones when possible
+podAntiAffinity:
+  enabled: true
+
+# Protect replicated application workloads during voluntary disruptions
+podDisruptionBudget:
+  enabled: true
+  minAvailable: 1


### PR DESCRIPTION
## What?
Add zone anti-affinity, container probes, and a Pod Disruption Budget to the HFF Helm chart.

## Why?
Resolve Core Cloud Kyverno policy warnings for the production deployment.

## How?
Updated the app and Redis Deployment templates and added a conditional PDB template.

## Testing?
Helm lint/render passed. Verified the changes on cc-hof-prod-1; all three policy requirements are present.

## Check list

- [x] I have reviewed my own pull request for linting issues (e.g. adding new lines)
- [ ] I have written tests (if relevant)
- [x] I have created a JIRA number for my branch
- [x] I have created a JIRA number for my commit
- [ ] Ensure drone builds are green especially tests
- [x] I will squash the commits before merging
